### PR TITLE
Support Single Quotes

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
-pub fn cd(args: Vec<&str>) -> Result<(), Box<dyn Error>> {
+pub fn cd(args: Vec<String>) -> Result<(), Box<dyn Error>> {
     let home = std::env::var("HOME").unwrap();
-    let path = args.first().map_or(home.as_str(), |s| *s);
+    let path = args.first().map_or(home.as_str(), |s| s.as_str());
     let mut path = path.to_string();
 
     // Replace ~ with the home directory
@@ -23,7 +23,7 @@ pub fn exit() -> Result<(), Box<dyn Error>> {
     std::process::exit(0);
 }
 
-pub fn echo(msg: Vec<&str>) -> Result<(), Box<dyn Error>> {
+pub fn echo(msg: Vec<String>) -> Result<(), Box<dyn Error>> {
     println!("{}", msg.join(" "));
     Ok(())
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,72 +1,68 @@
 use std::fmt::Display;
 
-
 #[derive(Debug)]
 pub struct TokenizedInput {
-  tokens: Vec<String>,
+    tokens: Vec<String>,
 }
 
 impl TokenizedInput {
-  pub fn cmd(&self) -> &String {
-    &self.tokens[0]
-  }
+    pub fn cmd(&self) -> &String {
+        &self.tokens[0]
+    }
 
-  pub fn args(&self) -> Vec<String> {
-    self.tokens[1..].to_vec()
-  }
+    pub fn args(&self) -> Vec<String> {
+        self.tokens[1..].to_vec()
+    }
 }
 
-pub fn clean<'a>(input: &'a mut String) -> &'a mut String {
-  *input = input.trim().to_string();
+pub fn clean(input: &mut String) -> &mut String {
+    *input = input.trim().to_string();
 
-  if input.ends_with('\n') { input.pop(); }
-  // Replace each whitespace with a single space
-  *input = input.split_whitespace().collect::<Vec<&str>>().join(" ");
+    if input.ends_with('\n') {
+        input.pop();
+    }
+    // Replace each whitespace with a single space
+    *input = input.split_whitespace().collect::<Vec<&str>>().join(" ");
 
-  input
+    input
 }
 
 pub fn tokenize(input: &mut String) -> TokenizedInput {
-  let mut in_quotes = false;
-  let mut current_token = String::new();
-  let mut tokens = Vec::<String>::new();
+    let mut in_quotes = false;
+    let mut current_token = String::new();
+    let mut tokens = Vec::<String>::new();
 
-  let cleaned = clean(input);
+    let cleaned = clean(input);
 
-  for c in cleaned.chars() {
-    match c {
-      '\'' => {
-        if in_quotes {
-          in_quotes = false;
-        } else {
-          in_quotes = true;
+    for c in cleaned.chars() {
+        match c {
+            '\'' => {
+                in_quotes = !in_quotes;
+            }
+            ' ' => {
+                if in_quotes {
+                    current_token.push(c);
+                } else {
+                    tokens.push(current_token);
+                    current_token = String::new();
+                }
+            }
+            _ => {
+                current_token.push(c);
+            }
         }
-      }
-      ' ' => {
-        if in_quotes {
-          current_token.push(c);
-        } else {
-          tokens.push(current_token);
-          current_token = String::new();
-        }
-      }
-      _ => {
-        current_token.push(c);
-      }
     }
-  }
-  // Add last token
-  tokens.push(current_token);
+    // Add last token
+    tokens.push(current_token);
 
-  // Remove empty strings
-  tokens.retain(|x| !x.is_empty());
+    // Remove empty strings
+    tokens.retain(|x| !x.is_empty());
 
-  TokenizedInput { tokens }
+    TokenizedInput { tokens }
 }
 
-
 impl Display for TokenizedInput {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{:?}", self.tokens)
-  }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.tokens)
+    }
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+
+
 #[derive(Debug)]
 pub struct TokenizedInput {
   tokens: Vec<String>,
@@ -59,4 +62,11 @@ pub fn tokenize(input: &mut String) -> TokenizedInput {
   tokens.retain(|x| !x.is_empty());
 
   TokenizedInput { tokens }
+}
+
+
+impl Display for TokenizedInput {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{:?}", self.tokens)
+  }
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,19 +1,62 @@
 #[derive(Debug)]
-pub struct TokenizedInput<'a> {
-    tokens: Vec<&'a str>,
+pub struct TokenizedInput {
+  tokens: Vec<String>,
 }
 
-impl<'a> TokenizedInput<'a> {
-    pub fn cmd(&self) -> &'a str {
-        self.tokens[0]
-    }
+impl TokenizedInput {
+  pub fn cmd(&self) -> &String {
+    &self.tokens[0]
+  }
 
-    pub fn args(&self) -> Vec<&'a str> {
-        self.tokens[1..].to_vec()
-    }
+  pub fn args(&self) -> Vec<String> {
+    self.tokens[1..].to_vec()
+  }
 }
 
-pub fn tokenize<'a>(input: &'a mut str) -> TokenizedInput<'a> {
-    let tokens: Vec<&'a str> = input.split_whitespace().collect();
-    TokenizedInput { tokens }
+pub fn clean<'a>(input: &'a mut String) -> &'a mut String {
+  *input = input.trim().to_string();
+
+  if input.ends_with('\n') { input.pop(); }
+  // Replace each whitespace with a single space
+  *input = input.split_whitespace().collect::<Vec<&str>>().join(" ");
+
+  input
+}
+
+pub fn tokenize(input: &mut String) -> TokenizedInput {
+  let mut in_quotes = false;
+  let mut current_token = String::new();
+  let mut tokens = Vec::<String>::new();
+
+  let cleaned = clean(input);
+
+  for c in cleaned.chars() {
+    match c {
+      '\'' => {
+        if in_quotes {
+          in_quotes = false;
+        } else {
+          in_quotes = true;
+        }
+      }
+      ' ' => {
+        if in_quotes {
+          current_token.push(c);
+        } else {
+          tokens.push(current_token);
+          current_token = String::new();
+        }
+      }
+      _ => {
+        current_token.push(c);
+      }
+    }
+  }
+  // Add last token
+  tokens.push(current_token);
+
+  // Remove empty strings
+  tokens.retain(|x| !x.is_empty());
+
+  TokenizedInput { tokens }
 }


### PR DESCRIPTION
The logic is basically:
1. Arguments are separate by spaces
2. Anything in the single quotes is included within the relevant argument as is. Therefore something like h'hello there' => hhello there.

![Screenshot from 2024-07-29 16-53-05](https://github.com/user-attachments/assets/e3868259-80f4-453d-a575-6846384dd765)

