### PR TITLE
Persist command history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "aish"
 version = "0.1.0"
 dependencies = [
+ "home",
  "nix 0.29.0",
  "rustyline",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+home = "0.5.9"
 nix = { version = "0.29.0", features = ["process", "fs"] }
-rustyline = "14.0.0"
+rustyline = { version = "14.0.0", features = ["with-file-history"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,12 @@ pub mod traits;
 
 use rustyline::error::ReadlineError;
 use rustyline::{DefaultEditor, Result};
+use home::home_dir;
 
 fn main() -> Result<()> {
     let mut rl = DefaultEditor::new()?;
+    let history = home_dir().unwrap().join(".aish_history");
+    let _ = rl.load_history(history.as_path());
     loop {
         let readline = rl.readline("> ");
         let mut buffer = match readline {
@@ -45,5 +48,6 @@ fn main() -> Result<()> {
             Err(e) => eprintln!("{}", e),
         }
     }
+    let _ = rl.save_history(history.as_path());
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ pub mod sequence;
 pub mod tokenize;
 pub mod traits;
 
+use home::home_dir;
 use rustyline::error::ReadlineError;
 use rustyline::{DefaultEditor, Result};
-use home::home_dir;
 
 fn main() -> Result<()> {
     let mut rl = DefaultEditor::new()?;


### PR DESCRIPTION
Saves file to `~/.aish_history`. Mimics `~/.bash_history`.