### PR TITLE
Execute commands as they are parsed (like bash)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use std::error::Error;
 
 #[derive(Error, Debug)]
 pub enum SyntaxError {
@@ -12,6 +13,8 @@ pub enum SyntaxError {
     InternalError,
     #[error("Invalid OPENAI_API_KEY: {0}")]
     InvalidOpenAIKey(String),
+    #[error("Runtime error: {0}")]
+    RuntimeError(#[from] Box<dyn Error>),
 }
 
 #[derive(Error, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ pub mod traits;
 extern crate log;
 extern crate simplelog;
 
-use crate::traits::Runnable;
 use home::home_dir;
 use parsing::parse;
 use rustyline::error::ReadlineError;
@@ -106,19 +105,8 @@ fn run_file_mode(file_path: &PathBuf) -> Result<(), std::io::Error> {
 fn execute_commands(commands: Vec<String>) {
     for command in commands {
         debug!("Executing command: {}", command);
-        let tokenized = match parse(command) {
-            Ok(tokenized) => tokenized,
-            Err(e) => {
-                eprintln!("Error in command: {}", e);
-                continue;
-            }
-        };
-        match tokenized.run() {
-            Ok(s) => {
-                if !s.is_empty() {
-                    println!("{}", s)
-                }
-            }
+        match parse(command) {
+            Ok(_) => {},
             Err(e) => eprintln!("Error in command: {}", e),
         }
     }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -9,9 +9,8 @@ use crate::parsing::lexer::lex_impl;
 use crate::parsing::parser::parse_impl;
 use crate::parsing::process::process;
 use crate::parsing::scanner::Scanner;
-use crate::sequence::Sequence;
 
-pub fn parse(input: String) -> Result<Sequence, Box<dyn Error>> {
+pub fn parse(input: String) -> Result<(), Box<dyn Error>> {
     debug!("User input: {}", input);
 
     let input = process(input);
@@ -22,8 +21,7 @@ pub fn parse(input: String) -> Result<Sequence, Box<dyn Error>> {
     debug!("Lexed tokens: {:?}", tokens);
 
     let mut scanner = Scanner::new(tokens);
-    let commands = parse_impl(&mut scanner)?;
-    debug!("Parsed commands: {:?}", commands);
+    parse_impl(&mut scanner)?;
 
-    Ok(commands)
+    Ok(())
 }


### PR DESCRIPTION
I have changed the processing of the commands to now process them as they are parsed. This makes is soooo much easier to do the `alias` command as the aliases on the left in examples like this `alias count_files='ls | wc -l' && count_files` are executed and stored in the aliases before the right side of the && are executed.